### PR TITLE
[clean]cryptosuite

### DIFF
--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -667,6 +667,7 @@ impl Credential {
             checks,
             eip712_domain,
             type_,
+            cryptosuite,
         } = options;
         if checks.is_some() {
             return Err(Error::UnencodableOptionClaim("checks".to_string()));

--- a/ssi-vc/src/lib.rs
+++ b/ssi-vc/src/lib.rs
@@ -681,6 +681,9 @@ impl Credential {
         if type_.is_some() {
             return Err(Error::UnencodableOptionClaim("type".to_string()));
         }
+        if cryptosuite.is_some() {
+            return Err(Error::UnencodableOptionClaim("cryptosuite".to_string()));
+        }
         match proof_purpose {
             None => (),
             Some(ProofPurpose::AssertionMethod) => (),


### PR DESCRIPTION
solve this problem.
```
error[E0027]: pattern does not mention field `cryptosuite`
   --> /ssi/ssi-vc/src/lib.rs:661:13
    |
661 |           let LinkedDataProofOptions {
    |  _____________^
662 | |             verification_method: _,
663 | |             proof_purpose,
664 | |             created,
...   |
669 | |             type_,
670 | |         } = options;
    | |_________^ missing field `cryptosuite`
    |
help: include the missing field in the pattern
    |
669 |             type_, cryptosuite } = options;
    |                  ~~~~~~~~~~~~~~~
help: if you don't care about this missing field, you can explicitly ignore it
    |
669 |             type_, .. } = options;
    |                  ~~~~~~

For more information about this error, try `rustc --explain E0027`.
error: could not compile `ssi-vc` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
Error: Compiling your crate to WebAssembly failed
Caused by: Compiling your crate to WebAssembly failed
Caused by: failed to execute `cargo build`: exited with exit status: 101
  full command: cd "/didkit/lib/web" && "cargo" "build" "--lib" "--release" "--target" "wasm32-unknown-unknown"
```